### PR TITLE
リダイレクトの処理、ビューの修正

### DIFF
--- a/assets/chat.css
+++ b/assets/chat.css
@@ -50,6 +50,7 @@ ul {
 }
 
 .left-users-content {
+  overflow: scroll;
   float: left;
   width: 300px;
   background-color: #f5f5f5f5;
@@ -110,6 +111,7 @@ a:visit{
 }
 
 .chat-main {
+  overflow: scroll;
   background-color: #fcfdff;
   width: 920px;
   height: 80%;

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -32,7 +32,9 @@ func PostSignupRouter(c *gin.Context) {
   password := c.PostForm("password")
   confirm_password := c.PostForm("confirm_password")
   data.Create_User(name, email, password, confirm_password)
-  c.HTML(200, "signin.html", nil)
+  user := data.Find_User(email, password)
+  session.Login(c, user)
+  c.Redirect(301, "/chatroom")
 }
 
 func SigninRouter(c *gin.Context) {
@@ -44,11 +46,11 @@ func PostSigninRouter(c *gin.Context) {
   password := c.PostForm("password")
   user := data.Find_User(email, password)
   session.Login(c, user)
-  c.HTML(200, "chat.html", nil)
+  c.Redirect(301, "/chatroom")
 }
 
 func PostMessage(c *gin.Context) {
   text := c.PostForm("text")
   data.Create_Message(c, text)
-  c.HTML(200, "chat.html", nil)
+  c.Redirect(301, "/chatroom")
 }


### PR DESCRIPTION
# What
リダイレクト処理
ビューの修正

# Why
ユーザーがサインアップしたあとにトーク画面に遷移するように設定する必要があるため。
画面外にメッセージがはみ出ていたため。